### PR TITLE
Change separator of commands in a pane.

### DIFF
--- a/lib/teamocil/tmux/pane.rb
+++ b/lib/teamocil/tmux/pane.rb
@@ -4,8 +4,10 @@ module Teamocil
       def as_tmux
         [].tap do |tmux|
           tmux << Teamocil::Command::SplitWindow.new(root: root, name: name) unless first?
-          tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: commands.join('; ')) if commands
-          tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: 'Enter')
+          commands.each do |command|
+            tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: command)
+            tmux << Teamocil::Command::SendKeysToPane.new(index: internal_index, keys: 'Enter')
+          end
           tmux << Teamocil::Command::SelectLayout.new(layout: layout, name: name) if layout
         end
       end

--- a/spec/teamocil/tmux/pane_spec.rb
+++ b/spec/teamocil/tmux/pane_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Teamocil::Tmux::Pane do
 
       it do
         expect(as_tmux).to eql [
-          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; bar'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'bar'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
           Teamocil::Command::SelectLayout.new(layout: layout, name: name)
         ]
@@ -35,7 +37,9 @@ RSpec.describe Teamocil::Tmux::Pane do
       it do
         expect(as_tmux).to eql [
           Teamocil::Command::SplitWindow.new(root: root, name: name),
-          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + index}", keys: 'foo; bar'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + index}", keys: 'foo'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + index}", keys: 'Enter'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + index}", keys: 'bar'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + index}", keys: 'Enter'),
           Teamocil::Command::SelectLayout.new(layout: layout, name: name)
         ]

--- a/spec/teamocil/tmux/window_spec.rb
+++ b/spec/teamocil/tmux/window_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe Teamocil::Tmux::Window do
   it do
     expect(as_tmux).to eql [
       Teamocil::Command::NewWindow.new(name: name),
-      Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+      Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+      Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+      Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
       Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
       Teamocil::Command::SplitWindow.new(name: name),
       Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + 1}", keys: 'bar'),
@@ -46,7 +48,9 @@ RSpec.describe Teamocil::Tmux::Window do
     it do
       expect(as_tmux).to eql [
         Teamocil::Command::NewWindow.new(name: name, root: root),
-        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
         Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
         Teamocil::Command::SplitWindow.new(name: name, root: root),
         Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + 1}", keys: 'bar'),
@@ -73,7 +77,9 @@ RSpec.describe Teamocil::Tmux::Window do
     it do
       expect(as_tmux).to eql [
         Teamocil::Command::NewWindow.new(name: name),
-        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
         Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
         Teamocil::Command::SelectLayout.new(layout: layout, name: name),
         Teamocil::Command::SplitWindow.new(name: name),
@@ -95,7 +101,9 @@ RSpec.describe Teamocil::Tmux::Window do
       expect(as_tmux).to eql [
         Teamocil::Command::NewWindow.new(name: name),
         Teamocil::Command::SetWindowOption.new(name: name, option: 'main-pane-width', value: '100'),
-        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+        Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
         Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
         Teamocil::Command::SelectLayout.new(layout: layout, name: name),
         Teamocil::Command::SplitWindow.new(name: name),
@@ -114,7 +122,9 @@ RSpec.describe Teamocil::Tmux::Window do
       it do
         expect(as_tmux).to eql [
           Teamocil::Command::RenameWindow.new(name: name),
-          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
           Teamocil::Command::SplitWindow.new(name: name),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + 1}", keys: 'bar'),
@@ -133,7 +143,9 @@ RSpec.describe Teamocil::Tmux::Window do
           Teamocil::Command::RenameWindow.new(name: name),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'cd "/tmp"'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
-          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo; omg'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'foo'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
+          Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'omg'),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index}", keys: 'Enter'),
           Teamocil::Command::SplitWindow.new(name: name, root: root),
           Teamocil::Command::SendKeysToPane.new(index: "#{name}.#{pane_base_index + 1}", keys: 'bar'),


### PR DESCRIPTION
Hi,

this merge request is related to the issue #133. For now _teamocil_ joins commands in _commands_ section with ';' symbol. The problem is that it does not work well with the terminal history. I think, in most cases only the last command is repeatable. The change gives users a possibility to choose between one liners:
```
[...]
- panes:
  - echo foo; echo bar
[...]
```
or commands performed one by one:
```
[...]
- panes:
  - commands:
    - echo foo
    - echo bar
[...]
```

PS.: Thank you for this cool gem.